### PR TITLE
Basic websocket support

### DIFF
--- a/database/user.go
+++ b/database/user.go
@@ -12,7 +12,9 @@ import (
 )
 
 const sessionDictionary = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+const accessKeyDictionary = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 const sessionLength = 256
+const accessKeyLength = 32
 
 // User stores a user account including the password using bcrypt.
 type User struct {
@@ -23,6 +25,7 @@ type User struct {
 	Password  string
 	Admin     bool
 	Session   string
+	AccessKey string
 }
 
 // ListUsers returns a list of all users.
@@ -48,6 +51,18 @@ func GetUser(email string) (*User, error) {
 func GetUserBySession(key string) (*User, error) {
 	u := &User{}
 	db.Where("session = ?", key).First(u)
+
+	if u.ID == 0 {
+		return nil, errors.New("Could not find user.")
+	}
+
+	return u, nil
+}
+
+// GetUserByAccessKey returns the user for a given access key.
+func GetUserByAccessKey(key string) (*User, error) {
+	u := &User{}
+	db.Where("access_key = ?", key).First(u)
 
 	if u.ID == 0 {
 		return nil, errors.New("Could not find user.")
@@ -139,9 +154,23 @@ func (u *User) NewSession() string {
 	}
 }
 
+// NewAccessKey generates a access key and stores it.
+func (u *User) NewAccessKey() string {
+	for {
+		key := generateAccessKey(accessKeyDictionary, accessKeyLength)
+
+		_, err := GetUserByAccessKey(key)
+
+		if err != nil {
+			u.AccessKey = key
+			db.Save(u)
+			return u.AccessKey
+		}
+	}
+}
+
 // generateSessionID generates a new session ID for a user combining the
 // email address and a random string.
-// dictionary and length are optional parameters used for testing.
 func generateSessionID(email, dictionary string, length int) string {
 	var random = make([]byte, length)
 	rand.Read(random)
@@ -154,6 +183,21 @@ func generateSessionID(email, dictionary string, length int) string {
 
 	hash := sha512.New()
 	hash.Write([]byte(joined))
+
+	return base64.StdEncoding.EncodeToString(hash.Sum(nil))
+}
+
+// generateAccessKey generates a new access key for a user.
+func generateAccessKey(dictionary string, length int) string {
+	var random = make([]byte, length)
+	rand.Read(random)
+
+	for k, v := range random {
+		random[k] = dictionary[v%byte(len(dictionary))]
+	}
+
+	hash := sha512.New()
+	hash.Write([]byte(random))
 
 	return base64.StdEncoding.EncodeToString(hash.Sum(nil))
 }

--- a/database/user.go
+++ b/database/user.go
@@ -12,9 +12,9 @@ import (
 )
 
 const sessionDictionary = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
-const accessKeyDictionary = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+const accessKeyDictionary = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-_?!+=%$&/()"
 const sessionLength = 256
-const accessKeyLength = 32
+const accessKeyLength = 64
 
 // User stores a user account including the password using bcrypt.
 type User struct {
@@ -196,10 +196,7 @@ func generateAccessKey(dictionary string, length int) string {
 		random[k] = dictionary[v%byte(len(dictionary))]
 	}
 
-	hash := sha512.New()
-	hash.Write([]byte(random))
-
-	return base64.StdEncoding.EncodeToString(hash.Sum(nil))
+	return string(random)
 }
 
 // HashPassword generates a hash using bcrypt.

--- a/database/user_test.go
+++ b/database/user_test.go
@@ -109,3 +109,20 @@ func TestGetUserbyID(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestNewAccessKey(t *testing.T) {
+	NewInMemoryDatabase()
+	user, _ := CreateUser("foo@bar.tld", "foo", "bar", "adsf", false)
+
+	key := user.NewAccessKey()
+
+	user2, err := GetUserByAccessKey(key)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if user.ID != user2.ID {
+		t.Error("Got the wrong user.")
+	}
+}

--- a/leeroy.go
+++ b/leeroy.go
@@ -8,10 +8,12 @@ import (
 	"github.com/fallenhitokiri/leeroyci/database"
 	"github.com/fallenhitokiri/leeroyci/runner"
 	"github.com/fallenhitokiri/leeroyci/web"
+	"github.com/fallenhitokiri/leeroyci/websocket"
 )
 
 func main() {
 	database.NewDatabase("", "")
+	websocket.NewServer()
 	go runner.Runner()
 
 	router := web.Routes()

--- a/notification/notify.go
+++ b/notification/notify.go
@@ -16,6 +16,8 @@ func Notify(job *database.Job, event string) {
 		return
 	}
 
+	sendWebsocket(job, event)
+
 	for _, notificaiton := range repo.Notifications {
 		switch notificaiton.Service {
 		case database.NotificationServiceEmail:

--- a/notification/websocket.go
+++ b/notification/websocket.go
@@ -1,0 +1,11 @@
+package notification
+
+import (
+	"github.com/fallenhitokiri/leeroyci/database"
+	"github.com/fallenhitokiri/leeroyci/websocket"
+)
+
+func sendWebsocket(job *database.Job, event string) {
+	msg := websocket.NewMessage(job, event)
+	websocket.Send(msg)
+}

--- a/web/middleware_accesskey.go
+++ b/web/middleware_accesskey.go
@@ -1,0 +1,38 @@
+package web
+
+import (
+	"net/http"
+
+	"github.com/fallenhitokiri/leeroyci/database"
+)
+
+// middlewareAccesskey tries to get a user by the access key in the
+// request header. If this is not possible we return a 401 error
+func middlewareAccessKey(next http.Handler) http.Handler {
+	fn := func(w http.ResponseWriter, r *http.Request) {
+		header := r.Header["Accesskey"]
+
+		if len(header) != 1 {
+			http.Error(w, "Wrong access key number", http.StatusBadRequest)
+			return
+		}
+
+		accessKey := header[0]
+
+		if accessKey == "" {
+			http.Error(w, "No access key", http.StatusBadRequest)
+			return
+		}
+
+		_, err := database.GetUserByAccessKey(accessKey)
+
+		if err != nil {
+			http.Error(w, "Access key not found", http.StatusUnauthorized)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	}
+
+	return http.HandlerFunc(fn)
+}

--- a/web/router.go
+++ b/web/router.go
@@ -32,6 +32,7 @@ func Routes() *mux.Router {
 	router.Handle("/search", chainAuth.ThenFunc(viewSearchJobs))
 
 	router.Handle("/user/settings", chainAuth.ThenFunc(viewUpdateUser))
+	router.Handle("/user/regenerate-accesskey", chainAuth.ThenFunc(viewRegenrateAccessKey))
 
 	router.Handle("/admin/users", chainAdmin.ThenFunc(viewAdminListUsers))
 	router.Handle("/admin/user/create", chainAdmin.ThenFunc(viewAdminCreateUser))
@@ -62,7 +63,7 @@ func Routes() *mux.Router {
 	staticFileServer := http.StripPrefix("/static/", http.FileServer(box.HTTPBox()))
 	router.Handle("/static/{path:.*}", middlewareLogging(staticFileServer))
 
-	router.Handle("/websocket", websocket.GetHandler())
+	router.Handle("/websocket", middlewareAccessKey(websocket.GetHandler()))
 
 	return router
 }

--- a/web/router.go
+++ b/web/router.go
@@ -7,6 +7,8 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/gorilla/sessions"
 	"github.com/justinas/alice"
+
+	"github.com/fallenhitokiri/leeroyci/websocket"
 )
 
 var sessionStore = sessions.NewCookieStore([]byte("something-very-secret"))
@@ -59,6 +61,8 @@ func Routes() *mux.Router {
 	box := rice.MustFindBox("static")
 	staticFileServer := http.StripPrefix("/static/", http.FileServer(box.HTTPBox()))
 	router.Handle("/static/{path:.*}", middlewareLogging(staticFileServer))
+
+	router.Handle("/websocket", websocket.GetHandler())
 
 	return router
 }

--- a/web/templates/user/admin/update.html
+++ b/web/templates/user/admin/update.html
@@ -43,7 +43,7 @@
                 <div class="form-group">
                     <label for="is_admin">Is an admin user</label>
                     <input type="checkbox" class="form-control" id="is_admin" name="is_admin" {{ if .edit_user.Admin }}checked{{ end }}>
-                </div>                
+                </div>
 
                 <button class="btn btn-info">Update User</button>
                 <a href="/admin/user/delete/{{ .edit_user.ID }}" class="btn btn-danger pull-right">Delete User</a>

--- a/web/templates/user/settings.html
+++ b/web/templates/user/settings.html
@@ -46,7 +46,12 @@
                     <input type="text" class="form-control" id="new_password" name="new_password" placeholder="Enter password">
                 </div>
 
-                <button class="btn btn-info">Update</button>
+                <div class="form-group">
+                    <p><strong>Access Key:</strong> {{ .user.AccessKey }}</p>
+                </div>
+
+                <button class="btn btn-info pull-right">Update</button>
+                <a href="/user/regenerate-accesskey" class="btn btn-default">Regenrate Access Key</a>
             </fieldset>
         </form>
     </div>

--- a/web/user.go
+++ b/web/user.go
@@ -75,3 +75,10 @@ func viewUpdateUser(w http.ResponseWriter, r *http.Request) {
 
 	render(w, r, template, ctx)
 }
+
+// viewRegenrateAccessKey regenerates the access key for a user.
+func viewRegenrateAccessKey(w http.ResponseWriter, r *http.Request) {
+	user := context.Get(r, contextUser).(*database.User)
+	user.NewAccessKey()
+	http.Redirect(w, r, "/user/settings", 302)
+}

--- a/websocket/client.go
+++ b/websocket/client.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"log"
 
-	"code.google.com/p/go.net/websocket"
+	"golang.org/x/net/websocket"
 )
 
 type client struct {

--- a/websocket/client.go
+++ b/websocket/client.go
@@ -1,0 +1,43 @@
+// Package websocket implements the websocket protocol according to RFC 6455.
+// Websockets are used to send updates for all events through the notifications
+// package.
+package websocket
+
+import (
+	"io"
+	"log"
+
+	"code.google.com/p/go.net/websocket"
+)
+
+type client struct {
+	socket *websocket.Conn
+}
+
+// NewClient returns a new websocket client.
+func NewClient(ws *websocket.Conn) *client {
+	return &client{
+		socket: ws,
+	}
+}
+
+func (c *client) write(msg *Message) {
+	websocket.JSON.Send(c.socket, msg)
+}
+
+func (c *client) listen() {
+	for {
+		select {
+
+		default:
+			var msg Message
+			err := websocket.JSON.Receive(c.socket, &msg)
+			if err == io.EOF {
+				socketServer.removeClient(c)
+				return
+			} else if err != nil {
+				log.Println(err)
+			}
+		}
+	}
+}

--- a/websocket/client/receiver.go
+++ b/websocket/client/receiver.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"code.google.com/p/go.net/websocket"
+)
+
+var origin = "http://localhost/"
+var url = "ws://localhost:8082/websocket"
+
+func main() {
+	ws, err := websocket.Dial(url, "", origin)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for {
+		var msg = make([]byte, 512)
+		_, err = ws.Read(msg)
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Printf("Receive: %s\n", msg)
+	}
+}

--- a/websocket/client/receiver.go
+++ b/websocket/client/receiver.go
@@ -4,14 +4,17 @@ import (
 	"fmt"
 	"log"
 
-	"code.google.com/p/go.net/websocket"
+	"golang.org/x/net/websocket"
 )
 
 var origin = "http://localhost/"
 var url = "ws://localhost:8082/websocket"
 
 func main() {
-	ws, err := websocket.Dial(url, "", origin)
+	config, err := websocket.NewConfig(url, origin)
+	config.Header["accesskey"] = []string{"gNV/bxhxG)IrvEeaZK_mA2HkCxC2yu!bHjGK!(MLNQ1tuDnUKyGBL9G/rGhXHNzU"}
+
+	ws, err := websocket.DialConfig(config)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/websocket/client_test.go
+++ b/websocket/client_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"code.google.com/p/go.net/websocket"
+	"golang.org/x/net/websocket"
 )
 
 func TestClient(t *testing.T) {

--- a/websocket/client_test.go
+++ b/websocket/client_test.go
@@ -1,0 +1,30 @@
+package websocket
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"code.google.com/p/go.net/websocket"
+)
+
+func TestClient(t *testing.T) {
+	http.Handle("/websocket", GetHandler())
+	server := httptest.NewServer(nil)
+	defer server.Close()
+	uri := fmt.Sprintf("ws://%s%s", server.Listener.Addr(), "/websocket")
+
+	ws, err := websocket.Dial(uri, "", "http://localhost")
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	client := NewClient(ws)
+
+	msg := &Message{
+		Event: "foo",
+	}
+	client.write(msg)
+}

--- a/websocket/message.go
+++ b/websocket/message.go
@@ -1,0 +1,32 @@
+// Package websocket implements the websocket protocol according to RFC 6455.
+// Websockets are used to send updates for all events through the notifications
+// package.
+package websocket
+
+import (
+	"github.com/fallenhitokiri/leeroyci/database"
+)
+
+// Message contains all fields consumed by differetn websockets to render
+// different events.
+type Message struct {
+	Name           string `json:"name"`
+	Email          string `json:"email"`
+	Event          string `json:"event"`
+	RepositoryName string `json:"repository_name"`
+	Branch         string `json:"branch"`
+	Status         string `json:"status"`
+}
+
+// NewMessage converts a job and event type to a message that can be send
+// through a websocket.
+func NewMessage(job *database.Job, event string) *Message {
+	return &Message{
+		Name:           job.Name,
+		Email:          job.Email,
+		Event:          event,
+		RepositoryName: job.Repository.Name,
+		Branch:         job.Branch,
+		Status:         job.Status(),
+	}
+}

--- a/websocket/message.go
+++ b/websocket/message.go
@@ -16,6 +16,7 @@ type Message struct {
 	RepositoryName string `json:"repository_name"`
 	Branch         string `json:"branch"`
 	Status         string `json:"status"`
+	URL            string `json:"url"`
 }
 
 // NewMessage converts a job and event type to a message that can be send
@@ -28,5 +29,6 @@ func NewMessage(job *database.Job, event string) *Message {
 		RepositoryName: job.Repository.Name,
 		Branch:         job.Branch,
 		Status:         job.Status(),
+		URL:            job.URL(),
 	}
 }

--- a/websocket/message_test.go
+++ b/websocket/message_test.go
@@ -1,0 +1,23 @@
+package websocket
+
+import (
+	"testing"
+
+	"github.com/fallenhitokiri/leeroyci/database"
+)
+
+func TestNewMessage(t *testing.T) {
+	database.NewInMemoryDatabase()
+	repo, _ := database.CreateRepository("foo", "baz", "accessKey", false, false)
+	job := database.CreateJob(repo, "branch", "commit", "commitURL", "name", "email")
+
+	msg := NewMessage(job, "foo")
+
+	if msg.Status != database.JobStatusPending {
+		t.Error("Wrong status", msg.Status)
+	}
+
+	if msg.RepositoryName != "foo" {
+		t.Error("Wrong repository name", msg.RepositoryName)
+	}
+}

--- a/websocket/server.go
+++ b/websocket/server.go
@@ -1,0 +1,65 @@
+// Package websocket implements the websocket protocol according to RFC 6455.
+// Websockets are used to send updates for all events through the notifications
+// package.
+package websocket
+
+import (
+	"log"
+
+	"code.google.com/p/go.net/websocket"
+)
+
+var socketServer *server
+
+type server struct {
+	clients []*client
+}
+
+// NewServer initializes a new websocket server.
+func NewServer() {
+	socketServer = &server{
+		clients: make([]*client, 0),
+	}
+}
+
+func (s *server) addClient(c *client) {
+	log.Println("Websocket added client")
+	s.clients = append(s.clients, c)
+}
+
+func (s *server) removeClient(c *client) {
+	log.Println("Websocket deleted client")
+	for index, client := range s.clients {
+		if client == c {
+			s.clients[index] = s.clients[len(s.clients)-1]
+			s.clients[len(s.clients)-1] = nil
+			s.clients = s.clients[:len(s.clients)-1]
+			return
+		}
+	}
+}
+
+// Send sends a message to all connected clients.
+func Send(msg *Message) {
+	for _, c := range socketServer.clients {
+		c.write(msg)
+	}
+}
+
+func connectHandler(ws *websocket.Conn) {
+	defer func() {
+		err := ws.Close()
+		if err != nil {
+			log.Println(err)
+		}
+	}()
+
+	client := NewClient(ws)
+	socketServer.addClient(client)
+	client.listen()
+}
+
+// GetHandler returns a net/http.Handler compatible handler for websockets.
+func GetHandler() websocket.Handler {
+	return websocket.Handler(connectHandler)
+}

--- a/websocket/server.go
+++ b/websocket/server.go
@@ -6,7 +6,7 @@ package websocket
 import (
 	"log"
 
-	"code.google.com/p/go.net/websocket"
+	"golang.org/x/net/websocket"
 )
 
 var socketServer *server

--- a/websocket/server_test.go
+++ b/websocket/server_test.go
@@ -1,0 +1,28 @@
+package websocket
+
+import (
+	"testing"
+)
+
+func TestAddRemove(t *testing.T) {
+	NewServer()
+	c1 := NewClient(nil)
+	c2 := NewClient(nil)
+	c3 := NewClient(nil)
+
+	socketServer.addClient(c1)
+	socketServer.addClient(c2)
+	socketServer.addClient(c3)
+
+	if len(socketServer.clients) != 3 {
+		t.Error("Wrong number of clients", len(socketServer.clients))
+	}
+
+	socketServer.removeClient(c2)
+
+	for _, c := range socketServer.clients {
+		if c == c2 {
+			t.Error("client c2 not removed")
+		}
+	}
+}


### PR DESCRIPTION
Add websocket support and introduce access keys.

Websockets do not filter any messages, they push *all* events to connected clients. It's the job of the client to only display information relevant to the user.

Access keys are attached to a user - a user can have *one* access key right now.